### PR TITLE
Make sure at least surefire 2.22.2 is used.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
     <assertj.version>3.13.2</assertj.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
   </properties>
 
   <dependencies>
@@ -78,6 +79,10 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
+      </plugin>
+      <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
       </plugin>
       <plugin>
         <!-- This generates a jar-file with our procedure code,


### PR DESCRIPTION
Otherwise tests won't run in a plain maven build but only in an IDE that replaces the default runner (like IDEA does) when recognizing JUnit 5.