### PR TITLE
Use correct commons-text artifact to get correct apoc.text.jaroWinklerDistance behavior in integration tests

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "Java17_maven",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/java:0-17",
+
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "none",
+      "installMaven": "true",
+      "installGradle": "false"
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,9 @@
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <assertj.version>3.22.0</assertj.version>
     <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
+
+    <!-- Use corrected JaroWinklerDistance implementation -->
+    <commons-text-version>1.10.0</commons-text-version>
   </properties>
 
   <dependencies>
@@ -72,6 +75,17 @@
     </dependency>
 
   </dependencies>
+  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <!-- Use version with correct JaroWinklerDistance impl. -->
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commons-text-version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>


### PR DESCRIPTION
Version 1.10.0 of Apache artifact `commons-text` correctly calculates the JaroWinkler "distance". Version 1.9 was actually buggy and returning the "similarity", which is `(1.0-distance)`.

The correct implementation is important, since it is used by the `apoc.text.jaroWinklerDistance` function. And if a custom plugin has a function or procedure dependent on `apoc.text.jaroWinklerDistance`, then its integration test can fail unless the correct version of `commons-text` is used.

This update also added a `devContainer.json` to enable building and running the tests using Github CodeSpace. 